### PR TITLE
add weights_only option to all torch.load()

### DIFF
--- a/animatediff/models/unet.py
+++ b/animatediff/models/unet.py
@@ -632,7 +632,7 @@ class UNet3DConditionModel(ModelMixin, ConfigMixin):
         if not os.path.isfile(model_file):
             raise RuntimeError(f"{model_file} does not exist")
         
-        state_dict = torch.load(model_file, map_location="cpu")
+        state_dict = torch.load(model_file, map_location="cpu", weights_only=False)
 
         if 'use_outpaint' in unet_additional_kwargs:
             model.conv_in.weight.data.zero_()

--- a/animatediff/utils/util.py
+++ b/animatediff/utils/util.py
@@ -235,7 +235,7 @@ def load_weights(
     unet_state_dict = {}
     if motion_module_path != "":
         print(f"load motion module from {motion_module_path}")
-        motion_module_state_dict = torch.load(motion_module_path, map_location="cpu")
+        motion_module_state_dict = torch.load(motion_module_path, map_location="cpu", weights_only=False)
         motion_module_state_dict = motion_module_state_dict["state_dict"] if "state_dict" in motion_module_state_dict else motion_module_state_dict
         unet_state_dict.update({name: param for name, param in motion_module_state_dict.items() if "motion_modules." in name})
     
@@ -251,7 +251,7 @@ def load_weights(
                 for key in f.keys():
                     dreambooth_state_dict[key] = f.get_tensor(key)
         elif dreambooth_model_path.endswith(".ckpt"):
-            dreambooth_state_dict = torch.load(dreambooth_model_path, map_location="cpu")
+            dreambooth_state_dict = torch.load(dreambooth_model_path, map_location="cpu", weights_only=False)
             
         # 1. vae
         converted_vae_checkpoint = convert_ldm_vae_checkpoint(dreambooth_state_dict, animation_pipeline.vae.config)
@@ -279,7 +279,7 @@ def load_weights(
         path, alpha = motion_module_lora_config["path"], motion_module_lora_config["alpha"]
         print(f"load motion LoRA from {path}")
 
-        motion_lora_state_dict = torch.load(path, map_location="cpu")
+        motion_lora_state_dict = torch.load(path, map_location="cpu", weights_only=False)
         motion_lora_state_dict = motion_lora_state_dict["state_dict"] if "state_dict" in motion_lora_state_dict else motion_lora_state_dict
 
         animation_pipeline = convert_motion_lora_ckpt_to_diffusers(animation_pipeline, motion_lora_state_dict, alpha)

--- a/diffusers/modeling_utils.py
+++ b/diffusers/modeling_utils.py
@@ -93,7 +93,7 @@ def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
     """
     try:
         if os.path.basename(checkpoint_file) == WEIGHTS_NAME:
-            return torch.load(checkpoint_file, map_location="cpu")
+            return torch.load(checkpoint_file, map_location="cpu", weights_only=False)
         else:
             return safetensors.torch.load_file(checkpoint_file, device="cpu")
     except Exception as e:

--- a/inference_outpainting-dir-with-prompt.py
+++ b/inference_outpainting-dir-with-prompt.py
@@ -172,7 +172,7 @@ def main(
         logging.info(f"from motion pretreained checkpoint: {motion_pretrained_model_path}")
     
         # motion model keys: 'epoch', 'global_step', 'state_dict'
-        motion_pretrained_model_path = torch.load(motion_pretrained_model_path, map_location="cpu")
+        motion_pretrained_model_path = torch.load(motion_pretrained_model_path, map_location="cpu", weights_only=False)
 
         if "global_step" in motion_pretrained_model_path: zero_rank_print(f"global_step: {motion_pretrained_model_path['global_step']}")
         state_dict = motion_pretrained_model_path["state_dict"] if "state_dict" in motion_pretrained_model_path else motion_pretrained_model_path

--- a/inference_outpainting-dir.py
+++ b/inference_outpainting-dir.py
@@ -174,7 +174,7 @@ def main(
         logging.info(f"from motion pretreained checkpoint: {motion_pretrained_model_path}")
     
         # motion model keys: 'epoch', 'global_step', 'state_dict'
-        motion_pretrained_model_path = torch.load(motion_pretrained_model_path, map_location="cpu")
+        motion_pretrained_model_path = torch.load(motion_pretrained_model_path, map_location="cpu", weights_only=False)
 
         if "global_step" in motion_pretrained_model_path: zero_rank_print(f"global_step: {motion_pretrained_model_path['global_step']}")
         state_dict = motion_pretrained_model_path["state_dict"] if "state_dict" in motion_pretrained_model_path else motion_pretrained_model_path

--- a/train.py
+++ b/train.py
@@ -220,7 +220,7 @@ def main(
         logging.info(f"from motion pretreained checkpoint: {motion_pretrained_model_path}")
     
         # motion model keys: 'epoch', 'global_step', 'state_dict'
-        motion_pretrained_model_path = torch.load(motion_pretrained_model_path, map_location="cpu")
+        motion_pretrained_model_path = torch.load(motion_pretrained_model_path, map_location="cpu", weights_only=False)
 
         if "global_step" in motion_pretrained_model_path: zero_rank_print(f"global_step: {motion_pretrained_model_path['global_step']}")
         state_dict = motion_pretrained_model_path["state_dict"] if "state_dict" in motion_pretrained_model_path else motion_pretrained_model_path
@@ -254,7 +254,7 @@ def main(
     
     if use_ip_plus_cross_attention and ip_pretrained_model_path!="":
         logging.info(f"from ip_pretrained_model_path checkpoint: {ip_pretrained_model_path}")
-        state_dict = torch.load(ip_pretrained_model_path, map_location="cpu")
+        state_dict = torch.load(ip_pretrained_model_path, map_location="cpu", weights_only=False)
         
         model_state_dict = unet.state_dict()
         image_proj_keys = []


### PR DESCRIPTION
I experienced the following warning for many times when I run the code.
```
FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly.
It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details).
In a future release, the default value for `weights_only` will be flipped to `True`.
This limits the functions that could be executed during unpickling.
Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`.
We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file.
Please open an issue on GitHub for any issues related to this experimental feature.
```
That's why I added `weights_only=False` to every `torch.load()` function to stop those warnings.